### PR TITLE
Get install / remove of nginx, flask and uwsgi working

### DIFF
--- a/time_lapse/DEBIAN/control
+++ b/time_lapse/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: time-lapse
-Version: 1.0.1
+Version: 1.0.3
 Section: custom
 Priority: optional
 Architecture: armhf
@@ -7,4 +7,4 @@ Essential: no
 Installed-Size: 1024
 Maintainer: Mark Dyer (heymarky@gmail.com)
 Description: Add time lapse tools to Raspberry Pi
-Depends: python3
+Depends: python3, python3-pip, nginx, python3-flask, uwsgi

--- a/time_lapse/DEBIAN/postrm
+++ b/time_lapse/DEBIAN/postrm
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+# This script typically modifies links or other files associated with
+# foo, and/or removes files created by the package.

--- a/time_lapse/DEBIAN/preinst
+++ b/time_lapse/DEBIAN/preinst
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# This script executes before that package will be unpacked from its
+# Debian archive (“.deb”) file. Many ‘preinst’ scripts stop services
+# for packages which are being upgraded until their installation or
+# upgrade is completed (following the successful execution of the
+# ‘postinst’ script).

--- a/time_lapse/DEBIAN/prerm
+++ b/time_lapse/DEBIAN/prerm
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+# This script typically stops any daemons which are associated with a
+# package. It is executed before the removal of files associated with
+# the package.
+
+systemctl stop nginx
+systemctl disable nginx
+


### PR DESCRIPTION
This repo now builds a debian package that installs nginx, flask and uwsgi as dependancies. 

Next step will be to run the simple flask app from uwsgi and serve that with nginx.